### PR TITLE
No cambiar el texto del label al cambiar el hidden

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -15,23 +15,19 @@
             <legend>Características</legend>
             <p>
                 <input type="checkbox" id="numbers" v-model="numbers" @change="generate()">
-                <label for="numbers" v-if="numbers">Números incluídos</label>
-                <label for="numbers" v-else class="red">No incluir números</label>
+                <label for="numbers" :class="!numbers ? 'red': ''">Números incluídos</label>
             </p>
             <p>
                 <input type="checkbox" id="mayus" v-model="mayus" @change="generate()">
-                <label for="mayus" v-if="mayus">Mayúsculas incluídas</label>
-                <label for="mayus" v-else class="red">No incluir mayusculas</label>
+                <label for="mayus" :class="!mayus ? 'red': ''">Mayúsculas incluídas</label>
             </p>
             <p>
                 <input type="checkbox" id="minus" v-model="minus" @change="generate()">
-                <label for="minus" v-if="minus">Minúsculas incluídas</label>
-                <label for="minus" v-else class="red">No incluir minúsculas</label>
+                <label for="minus" :class="!minus ? 'red': ''">Minúsculas incluídas</label>
             </p>
             <p>
                 <input type="checkbox" id="symbols" v-model="symbols" @change="generate()">
-                <label for="symbols" v-if="symbols">Símbolos y caracteres especiales incluídos</label>
-                <label for="symbols" v-else class="red">No incluir símbolos o caracteres especiales</label>
+                <label for="symbols" :class="!symbols ? 'red': ''">Símbolos y caracteres especiales incluídos</label>
             </p>
             <hr>
             <p>

--- a/src/App.vue
+++ b/src/App.vue
@@ -44,8 +44,7 @@
             </p>
             <p>
                 <input type="checkbox" id="hidden" v-model="hidden" @change="generate()">
-                <label for="hidden" v-if="hidden">Ocultar la contraseña generada</label>
-                <label for="hidden" v-else>No ocultar la contraseña generada</label>
+                <label for="hidden">Ocultar la contraseña generada</label>
             </p>
         </fieldset>
         <section>


### PR DESCRIPTION
Al modificar el valor de hidden (si muestra o no la contraseña), cambia el texto del checkbox, cosa que no tiene mucho sentido de primeras, y además los textos que muestra son un poco erróneos, ya que por ejemplo si quieres ocultar la contraseña, debes marcar el checkbox cuyo texto es: "No ocultar la contraseña generada", y de la misma forma, para mostrar la contraseña, debes desmarcar la opción "Ocultar contraseña". Adjunto fotos.

![image](https://user-images.githubusercontent.com/13428280/125185878-7c2f2b00-e227-11eb-9b19-7c6f6e9d4c97.png)
---
![image](https://user-images.githubusercontent.com/13428280/125185945-ca442e80-e227-11eb-993e-d417e4090a9c.png)
